### PR TITLE
必要なスコープに関するドキュメントを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ go.work.sum
 
 # env file
 .env
+.envrc
+
+# database file
+plusplus.db
+
+# binary file
+plusplusbot

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The following settings are required to run this bot:
   - `channels:history` (to read channel message history)
   - `chat:write` (to send messages)
   - `user:read` (to read user information)
+- Event Subscriptions
+  - Bot Events
+    - `message.channels` (to handle channel messages)
+
+See our example [slack-app-manifest.json](slack-app-manifest.json) for more details.
 
 ## Setup
 

--- a/slack-app-manifest.json
+++ b/slack-app-manifest.json
@@ -1,0 +1,34 @@
+{
+  "display_information": {
+    "name": "plusplusbot"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "plusplusbot",
+      "always_online": false
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:history",
+        "chat:write",
+        "users:read"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": [
+        "message.channels"
+      ]
+    },
+    "interactivity": {
+      "is_enabled": true
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": true,
+    "token_rotation_enabled": false
+  }
+}


### PR DESCRIPTION
plusplus bot をローカルで動かしてみたところ、Event Subscriptions に追加のスコープが必要そうだったので README に追加しました

<img width="1338" height="562" alt="CleanShot 2025-08-30 at 15 43 39@2x" src="https://github.com/user-attachments/assets/5e300db5-a3f6-4563-bdd3-9f8143926526" />

自分の環境だとこのスコープがないと `@hoge ++` してもBotが反応してくれなかったです

参考までに slack app のマニフェストファイルも追加しています