### PR TITLE
絵文字にもplusplusできるようにする

### DIFF
--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -139,6 +139,36 @@ func TestDetectPointOperation(t *testing.T) {
 			want: PointCheck,
 		},
 		{
+			name: "Emoji point up",
+			text: ":sake: ++",
+			want: PointUp,
+		},
+		{
+			name: "Emoji point down",
+			text: ":sake: --",
+			want: PointDown,
+		},
+		{
+			name: "Emoji point check",
+			text: ":sake: ==",
+			want: PointCheck,
+		},
+		{
+			name: "Emoji with underscores",
+			text: ":beer_mug: ++",
+			want: PointUp,
+		},
+		{
+			name: "Emoji with numbers",
+			text: ":beer2: ++",
+			want: PointUp,
+		},
+		{
+			name: "Emoji with spaces",
+			text: ":sake:   ++",
+			want: PointUp,
+		},
+		{
 			name: "No operation",
 			text: "Hello world",
 			want: NoOperation,
@@ -151,6 +181,11 @@ func TestDetectPointOperation(t *testing.T) {
 		{
 			name: "Invalid format with newline",
 			text: "<@U123456>\n++",
+			want: NoOperation,
+		},
+		{
+			name: "Invalid emoji format",
+			text: ":sake +",
 			want: NoOperation,
 		},
 	}
@@ -193,6 +228,95 @@ func TestExtractUserID(t *testing.T) {
 			got := extractUserID(tt.text)
 			if got != tt.want {
 				t.Errorf("extractUserID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractEmojiName(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "Valid emoji",
+			text: ":sake: ++",
+			want: "sake",
+		},
+		{
+			name: "Emoji with underscores",
+			text: ":beer_mug: ++",
+			want: "beer_mug",
+		},
+		{
+			name: "Emoji with numbers",
+			text: ":beer2: ++",
+			want: "beer2",
+		},
+		{
+			name: "No emoji",
+			text: "Hello world",
+			want: "",
+		},
+		{
+			name: "Invalid emoji format",
+			text: ":sake ++",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractEmojiName(tt.text)
+			if got != tt.want {
+				t.Errorf("extractEmojiName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTargetFromText(t *testing.T) {
+	tests := []struct {
+		name         string
+		text         string
+		wantTarget   string
+		wantIsUser   bool
+	}{
+		{
+			name:         "User mention",
+			text:         "<@U123456>++",
+			wantTarget:   "U123456",
+			wantIsUser:   true,
+		},
+		{
+			name:         "Emoji",
+			text:         ":sake: ++",
+			wantTarget:   "sake",
+			wantIsUser:   false,
+		},
+		{
+			name:         "No target",
+			text:         "Hello world",
+			wantTarget:   "",
+			wantIsUser:   false,
+		},
+		{
+			name:         "User mention has priority",
+			text:         "<@U123456> :sake: ++",
+			wantTarget:   "U123456",
+			wantIsUser:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTarget, gotIsUser := extractTargetFromText(tt.text)
+			if gotTarget != tt.wantTarget {
+				t.Errorf("extractTargetFromText() gotTarget = %v, want %v", gotTarget, tt.wantTarget)
+			}
+			if gotIsUser != tt.wantIsUser {
+				t.Errorf("extractTargetFromText() gotIsUser = %v, want %v", gotIsUser, tt.wantIsUser)
 			}
 		})
 	}

--- a/bot/messages.go
+++ b/bot/messages.go
@@ -47,7 +47,7 @@ func init() {
 	}
 }
 
-func getFormattedMessage(messageType MessageType, userID string, points int) string {
+func getFormattedMessage(messageType MessageType, target string, points int, isUser bool) string {
 	var reaction, template string
 	switch messageType {
 	case PlusPointsMessage:
@@ -65,9 +65,16 @@ func getFormattedMessage(messageType MessageType, userID string, points int) str
 	}
 
 	pointsStr := fmt.Sprintf("%d points", points)
-	username := fmt.Sprintf("<@%s>", userID)
+	
+	// Format target based on whether it's a user or emoji
+	var targetStr string
+	if isUser {
+		targetStr = fmt.Sprintf("<@%s>", target)
+	} else {
+		targetStr = fmt.Sprintf(":%s:", target)
+	}
 
-	message := strings.ReplaceAll(template, "{thing}", username)
+	message := strings.ReplaceAll(template, "{thing}", targetStr)
 	message = strings.ReplaceAll(message, "{points_string}", pointsStr)
 	if reaction != "" {
 		message = fmt.Sprintf("%s %s", reaction, message)

--- a/bot/messages_test.go
+++ b/bot/messages_test.go
@@ -9,43 +9,72 @@ func TestGetFormattedMessage(t *testing.T) {
 	tests := []struct {
 		name         string
 		messageType  MessageType
-		userID       string
+		target       string
 		points       int
+		isUser       bool
 		wantContains []string
 	}{
 		{
-			name:         "PlusPointsMessage",
+			name:         "PlusPointsMessage for user",
 			messageType:  PlusPointsMessage,
-			userID:       "U123456",
+			target:       "U123456",
 			points:       5,
+			isUser:       true,
 			wantContains: []string{"<@U123456>", "5 points"},
 		},
 		{
-			name:         "MinusPointsMessage",
+			name:         "PlusPointsMessage for emoji",
+			messageType:  PlusPointsMessage,
+			target:       "sake",
+			points:       5,
+			isUser:       false,
+			wantContains: []string{":sake:", "5 points"},
+		},
+		{
+			name:         "MinusPointsMessage for user",
 			messageType:  MinusPointsMessage,
-			userID:       "U789012",
+			target:       "U789012",
 			points:       -3,
+			isUser:       true,
 			wantContains: []string{"<@U789012>", "-3 points"},
 		},
 		{
-			name:         "EqualsMessage",
+			name:         "MinusPointsMessage for emoji",
+			messageType:  MinusPointsMessage,
+			target:       "beer",
+			points:       -3,
+			isUser:       false,
+			wantContains: []string{":beer:", "-3 points"},
+		},
+		{
+			name:         "EqualsMessage for user",
 			messageType:  EqualsMessage,
-			userID:       "U345678",
+			target:       "U345678",
 			points:       0,
+			isUser:       true,
 			wantContains: []string{"<@U345678>", "0 points"},
+		},
+		{
+			name:         "EqualsMessage for emoji",
+			messageType:  EqualsMessage,
+			target:       "coffee",
+			points:       0,
+			isUser:       false,
+			wantContains: []string{":coffee:", "0 points"},
 		},
 		{
 			name:         "SelfMessage",
 			messageType:  SelfMessage,
-			userID:       "U901234",
+			target:       "U901234",
 			points:       0,
+			isUser:       true,
 			wantContains: []string{"<@U901234>"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getFormattedMessage(tt.messageType, tt.userID, tt.points)
+			got := getFormattedMessage(tt.messageType, tt.target, tt.points, tt.isUser)
 
 			// For PlusPointsMessage and MinusPointsMessage, check if there's a reaction
 			if tt.messageType == PlusPointsMessage || tt.messageType == MinusPointsMessage {


### PR DESCRIPTION
本家の plusplusbot と同様に絵文字にも plusplus できるようにします

本家では `# :sake: ++` のように前に `#` をつける必要がありましたが、直感的ではないので `#` なしで絵文字に直接plusplusできる仕様にしています

<img width="734" height="220" alt="CleanShot 2025-08-30 at 17 47 46@2x" src="https://github.com/user-attachments/assets/dc4b2d14-4bc5-48be-9a9b-8d29027f4cfb" />

懸念点としては DB の変更をしていないので `user_id` カラムに直接絵文字の文言が入るようになっていることで、DBの変更も必要だったら教えてください（なぜか `is_user` と言うカラムはあった）

<img width="1316" height="214" alt="CleanShot 2025-08-30 at 17 49 26@2x" src="https://github.com/user-attachments/assets/20f1fd2b-7176-4790-9f44-ab7481ec026e" />
