### PR TITLE
fix: tagprからrelease実行を削除しタグpushトリガーに一本化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 jobs:
   goreleaser:

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -25,10 +25,5 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
       - uses: Songmu/tagpr@v1
-        id: tagpr
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-      - uses: ./.github/actions/release
-        if: steps.tagpr.outputs.tag != ''
-        with:
-          github_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary
- tagpr.ymlからgoreleaserの呼び出しを削除し、タグ作成のみに変更
- release.ymlのタグパターンを `v*` → `v[0-9]*.[0-9]*.[0-9]*` に厳密化
- tagprとrelease.ymlの両方でgoreleaserが実行されアセット重複アップロードで失敗していた問題を解消

## Test plan
- [ ] mainマージ後にtagprがタグを作成することを確認
- [ ] タグpush時にrelease.ymlのみがトリガーされることを確認
- [ ] goreleaserがアセットを正常にアップロードできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)