### PR TITLE
fix: ++/--/== の後に文字列が続く場合は反応しないよう修正

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -84,9 +84,9 @@ const (
 // Pre-compiled regexes for detecting point operations with targets
 var (
 	// User mention pattern: <@U123456> ++ (captures user ID and operator)
-	userOperationPattern = regexp.MustCompile(`<@([A-Z0-9]+)>[ 　]*(\+\+|-{2}|={2})`)
+	userOperationPattern = regexp.MustCompile(`<@([A-Z0-9]+)>[ 　]*(\+\+|-{2}|={2})[ 　]*($|\n)`)
 	// Emoji pattern: :emoji: ++ (captures emoji name and operator)
-	emojiOperationPattern = regexp.MustCompile(`:([a-zA-Z0-9_+-]+):[ 　]*(\+\+|-{2}|={2})`)
+	emojiOperationPattern = regexp.MustCompile(`:([a-zA-Z0-9_+-]+):[ 　]*(\+\+|-{2}|={2})[ 　]*($|\n)`)
 )
 
 // parseOperator converts an operator string to a PointOperation

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -383,6 +383,70 @@ func TestDetectOperationAndTarget(t *testing.T) {
 			wantTarget: "U123456",
 			wantIsUser: true,
 		},
+		// Operator must be at end of line or followed by newline
+		{
+			name:       "Emoji operator followed by text",
+			text:       ":nya-nya: -- Settings",
+			wantOp:     NoOperation,
+			wantTarget: "",
+			wantIsUser: false,
+		},
+		{
+			name:       "Emoji operator followed by text (plus)",
+			text:       ":neko: ++ foo",
+			wantOp:     NoOperation,
+			wantTarget: "",
+			wantIsUser: false,
+		},
+		{
+			name:       "Emoji operator followed by text (equals)",
+			text:       ":neko: == foo",
+			wantOp:     NoOperation,
+			wantTarget: "",
+			wantIsUser: false,
+		},
+		{
+			name:       "Emoji operator followed by trailing spaces",
+			text:       ":neko: ++   ",
+			wantOp:     PointUp,
+			wantTarget: "neko",
+			wantIsUser: false,
+		},
+		{
+			name:       "Emoji operator followed by newline",
+			text:       ":neko: ++\n",
+			wantOp:     PointUp,
+			wantTarget: "neko",
+			wantIsUser: false,
+		},
+		{
+			name:       "Emoji operator followed by newline and text",
+			text:       ":neko: ++\nsome text",
+			wantOp:     PointUp,
+			wantTarget: "neko",
+			wantIsUser: false,
+		},
+		{
+			name:       "User operator followed by text",
+			text:       "<@U123456> ++ foo",
+			wantOp:     NoOperation,
+			wantTarget: "",
+			wantIsUser: false,
+		},
+		{
+			name:       "User operator followed by trailing spaces",
+			text:       "<@U123456> ++   ",
+			wantOp:     PointUp,
+			wantTarget: "U123456",
+			wantIsUser: true,
+		},
+		{
+			name:       "User operator followed by newline and text",
+			text:       "<@U123456> ++\nsome text",
+			wantOp:     PointUp,
+			wantTarget: "U123456",
+			wantIsUser: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 背景

`:stamp1: Check it out :point-down::skin-tone-2:/ -- Settings` のようなメッセージで、意図せず `:stamp1:` のポイントが減算されるという問題があった。

#114 は「絵文字などの間に文字がある場合にも反応してしまう」問題として修正されたが、元のコードでも絵文字とオペレーターの間に文字がある場合は反応しない実装になっていた。

実際の原因は、`:point-down::skin-tone-2:/ --` の部分にあった。`:skin-tone-2:` と `--` が隣接（または近接）しており、これが正規表現にマッチしていた。

- **#114 以前**: マッチした場合、メッセージ内で最初に登場する絵文字をターゲットとして選ぶ実装だったため、`:stamp1:` にポイントが減算されていた
- **#114 以降**: マッチした絵文字とオペレーターを同時に検出するよう改善されたため、`:skin-tone-2:` がターゲットになるようになった。しかしスキントーンがポイントの対象になるのも意図した挙動ではない

## 変更内容

根本的な解決策として、`++`/`--`/`==` の後に別の文字列が続く場合は反応しないよう正規表現を修正した。

`userOperationPattern` / `emojiOperationPattern` の末尾に `[ 　]*($|\n)` を追加し、オペレーターの直後がスペースのみ・行末・改行の場合のみ反応するようにした。

これにより `-- Settings` のように `--` の後に単語が続くケースでは反応しなくなる。