### PR TITLE
feat: ++ の連打 (++++) でもポイントを付与できるようにする

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -84,19 +84,22 @@ const (
 // Pre-compiled regexes for detecting point operations with targets
 var (
 	// User mention pattern: <@U123456> ++ (captures user ID and operator)
-	userOperationPattern = regexp.MustCompile(`<@([A-Z0-9]+)>[ 　]*(\+\+|-{2}|={2})[ 　]*($|\n)`)
+	userOperationPattern = regexp.MustCompile(`<@([A-Z0-9]+)>[ 　]*(\+{2,}|-{2}|={2})[ 　]*($|\n)`)
 	// Emoji pattern: :emoji: ++ (captures emoji name and operator)
-	emojiOperationPattern = regexp.MustCompile(`:([a-zA-Z0-9_+-]+):[ 　]*(\+\+|-{2}|={2})[ 　]*($|\n)`)
+	emojiOperationPattern = regexp.MustCompile(`:([a-zA-Z0-9_+-]+):[ 　]*(\+{2,}|-{2}|={2})[ 　]*($|\n)`)
 )
 
 // parseOperator converts an operator string to a PointOperation
 func parseOperator(op string) PointOperation {
-	switch op {
-	case "++":
+	if len(op) < 2 {
+		return NoOperation
+	}
+	switch op[0] {
+	case '+':
 		return PointUp
-	case "--":
+	case '-':
 		return PointDown
-	case "==":
+	case '=':
 		return PointCheck
 	default:
 		return NoOperation

--- a/bot/bot_test.go
+++ b/bot/bot_test.go
@@ -169,6 +169,27 @@ func TestDetectPointOperation(t *testing.T) {
 			want: PointUp,
 		},
 		{
+			name: "Repeated plus (++++)",
+			text: "<@U123456> ++++",
+			want: PointUp,
+		},
+		{
+			name: "Emoji repeated plus",
+			text: ":sake: +++",
+			want: PointUp,
+		},
+		// 連打対応は + のみ。-- / == は従来どおり2文字ちょうど
+		{
+			name: "Repeated minus is not supported",
+			text: "<@U123456> ----",
+			want: NoOperation,
+		},
+		{
+			name: "Repeated equals is not supported",
+			text: "<@U123456> ====",
+			want: NoOperation,
+		},
+		{
 			name: "No operation",
 			text: "Hello world",
 			want: NoOperation,
@@ -244,10 +265,32 @@ func TestDetectOperationAndTarget(t *testing.T) {
 			wantTarget: "U123456",
 			wantIsUser: true,
 		},
+		// 連打 (repeated operators) should still register
+		{
+			name:       "User repeated plus",
+			text:       "<@U123456> ++++",
+			wantOp:     PointUp,
+			wantTarget: "U123456",
+			wantIsUser: true,
+		},
+		{
+			name:       "User repeated plus no space",
+			text:       "<@U123456>+++++++++",
+			wantOp:     PointUp,
+			wantTarget: "U123456",
+			wantIsUser: true,
+		},
 		// Normal cases: emoji
 		{
 			name:       "Emoji point up",
 			text:       ":sake: ++",
+			wantOp:     PointUp,
+			wantTarget: "sake",
+			wantIsUser: false,
+		},
+		{
+			name:       "Emoji repeated plus",
+			text:       ":sake: ++++",
 			wantOp:     PointUp,
 			wantTarget: "sake",
 			wantIsUser: false,
@@ -464,4 +507,3 @@ func TestDetectOperationAndTarget(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## なぜ

Slack で「テンションが上がって `++++` 連打した時でもプラスされて欲しい」という要望がありました。
https://pepabo.slack.com/archives/C0BBA6Z49DK/p1782716382278819

現状、演算子の正規表現が `\+\+`（ちょうど2文字）にしかマッチせず、直後に行末を要求するため、
`++++` のように3文字以上連打すると**マッチ全体が失敗して無反応**になっていました
（`+` が3個以上だと反応しない）。`parseOperator` も `case "++"` の完全一致でした。

## なにを

- `bot/bot.go` の **`+` のみ** 2文字以上許容に変更（`\+\+` → `\+{2,}`、user メンション・絵文字の両パターン）
  - `--` / `==` は **従来どおり2文字ちょうど**（`----`・`====` は無反応のまま）
- `parseOperator` を先頭文字での判定に変更（`+++`, `++++` を拾えるように）
- 加点量は連打数によらず **+1**（`++++++++` でも +1。`pointsChange = 1` 固定のまま）

## テスト

- 連打ケースを追加: `++++` / `+++++++++` / 絵文字 `+++` は PointUp、`----` / `====` は NoOperation
- `go test ./bot/`（`-race` 含む）全パス。単独 `+` は無反応・演算子は行末必須、といった既存仕様は維持

## 動作（修正後）

| 入力 | 修正前 | 修正後 |
|---|---|---|
| `@user ++` | +1 | +1 |
| `@user ++++` / `++++++++` | 無反応 | **+1** |
| `:sake: +++` | 無反応 | **+1** |
| `@user +`（単独） | 無反応 | 無反応（据え置き）|
| `@user ----` / `====` | 無反応 | 無反応（据え置き）|

🤖 Generated with [Claude Code](https://claude.com/claude-code)